### PR TITLE
Handle special fields "date" and "slug" separately.

### DIFF
--- a/src/Exports/EntriesExport.php
+++ b/src/Exports/EntriesExport.php
@@ -37,11 +37,38 @@ class EntriesExport implements FromCollection, WithStyles
         foreach ($keys as $key => $label) {
             // Add the key to the collection if it doesn't exist
             foreach ($this->items as $index => $item) {
+                // Handle special field "date" separately
+                if ($key === 'date' && $item->hasDate()) {
+                    $date = $item->date();
+
+                    if ($date instanceof \Illuminate\Support\Carbon) {
+                        if ($item->hasSeconds()) {
+                            $value = $date->format('Y-m-d H:i:s');
+                        } elseif ($item->hasTime()) {
+                            $value = $date->format('Y-m-d H:i');
+                        } else {
+                            $value = $date->format('Y-m-d');
+                        }
+                    } else {
+                        $value = $date ?? '';
+                    }
+
+                    $result[$index][$key] = $value;
+                    continue;
+                }
+
+                // Handle special field "slug" separately
+                if ($key === 'slug') {
+                    $result[$index][$key] = $item->slug() ?? '';
+                    continue;
+                }
+
                 // If the key doesn't exist, add an empty string to avoid unnecessary augmentation.
                 if ($item->get($key) === null) {
                     $result[$index][$key] = ''; // Necessary to prevent mixing up columns
                     continue;
                 }
+
                 $value = $item->augmentedValue($key);
                 $result[$index][$key] = $this->toString($value);
             }


### PR DESCRIPTION
Hi! First of all, thanks for a really useful addon!

I noticed that some special Statamic fields were empty in my exports.

If you have a [dated collection](https://statamic.dev/collections#dates) the "date" field will be included when collecting fields through `Entry::blueprint()->fields()->all()` but unlike normal fields the `$entry->get('date')` method will return `null` - you'll have to use `$entry->date()` to retrieve the date.

Similarly, if you have a "slug" field then `$entry->get('slug')` will return `null` - you'll have to use `$entry->slug()` to retrieve the slug.

I wrote a quick fix for these two issues. Note that I have only tested this code in Statamic 4.58.0.