### PR TITLE
Allow exporting Bard fields

### DIFF
--- a/src/Exports/EntriesExport.php
+++ b/src/Exports/EntriesExport.php
@@ -104,7 +104,6 @@ class EntriesExport implements FromCollection, WithStyles
 
         if (
             $fieldType instanceof \Statamic\Fieldtypes\Text // Slug field type inherits from Text and therefore must not be checked separately
-            || $fieldType instanceof \Statamic\Fieldtypes\Bard
             || $fieldType instanceof \Statamic\Fieldtypes\Markdown
             || $fieldType instanceof \Statamic\Fieldtypes\Textarea
             || $fieldType instanceof \Statamic\Fieldtypes\Video
@@ -124,6 +123,10 @@ class EntriesExport implements FromCollection, WithStyles
 
         if ($fieldType instanceof \Statamic\Fieldtypes\Toggle) {
             return $value->value() ? 'yes' : 'no';
+        }
+
+        if ($fieldType instanceof \Statamic\Fieldtypes\Bard) {
+            return json_encode($value->value());
         }
 
         if (


### PR DESCRIPTION
Hi 👋 Fantastic little addon, thanks so much for making this!

### Description of changes

I recently encountered issue #5 when exporting pages that contain a Bard field. This pull request aims to enable Bard exports by JSON-encoding their contents, which prevents the server error that currently blocks exports in these cases.

### Alternative way of exporting Bard fields

Instead of exporting them as JSON, you could render them as HTML. Depending on your intended use for the export, either option could be effective. This might be something to configure in the future.

```php
use Statamic\Fieldtypes\Bard\Augmentor;

if ($fieldType instanceof \Statamic\Fieldtypes\Bard) {
  return (new Augmentor($fieldType))->withStatamicImageUrls()->convertToHtml($value->value());
}
```