### PR TITLE
fix selects without labels

### DIFF
--- a/src/Exports/EntriesExport.php
+++ b/src/Exports/EntriesExport.php
@@ -146,7 +146,7 @@ class EntriesExport implements FromCollection, WithStyles
             || $fieldType instanceof \Statamic\Fieldtypes\Select
             || $fieldType instanceof \Statamic\Fieldtypes\Width
         ) {
-            return $value->value()->label();
+            return $value->value()->label() ?? $value->raw();
         }
 
         if (


### PR DESCRIPTION
Select fields in Statamic are not required to have labels (you will see the label is optional when creating a select field in a blueprint). However, the exporter will crash if it encounters a select field without a label. It crashes with the error,

```
[2025-01-26 21:34:39] local.ERROR: Doefom\StatamicExport\Exports\EntriesExport::toString(): Return value must be of type string, null returned {"userId":"4dde1448-45e4-4650-ab60-364040fd6401","exception":"[object] (TypeError(code: 0): Doefom\\StatamicExport\\Exports\\EntriesExport::toString(): Return value must be of type string, null returned at /Users/efc/Herd/play/vendor/doefom/statamic-export/src/Exports/EntriesExport.php:149)
```
This pull request fixes that bug by falling back to `$value->raw()` when `$value->label()` returns nothing.
