### PR TITLE
Adds support for fieldtype mappings to handle abitrary fields

### DIFF
--- a/config/statamic/export.php
+++ b/config/statamic/export.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Support\Arr;
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Fieldtype Mappings
+    |--------------------------------------------------------------------------
+    |
+    | Define custom mappings for how specific fieldtypes should be converted to
+    | strings during export. Each key should be the fully qualified class name
+    | of the fieldtype, and the value should be a closure that receives the
+    | field value and returns a string.
+    |
+    */
+    'fieldtype_mappings' => [
+        // Example:
+        // \Custom\Fieldtype::class => function (\Statamic\Fields\Value $value) {
+        //     ... do something with the value ...
+        //     return (string) $transformedValue;
+        // },
+    ]
+];

--- a/src/Exports/EntriesExport.php
+++ b/src/Exports/EntriesExport.php
@@ -101,6 +101,13 @@ class EntriesExport implements FromCollection, WithStyles
         }
 
         $fieldType = $value->fieldtype();
+        $fieldTypeClass = get_class($fieldType);
+
+        // Check for custom mapping
+        $mappings = config('statamic.export.fieldtype_mappings', []);
+        if (isset($mappings[$fieldTypeClass])) {
+            return (string) $mappings[$fieldTypeClass]($value);
+        }
 
         if (
             $fieldType instanceof \Statamic\Fieldtypes\Text // Slug field type inherits from Text and therefore must not be checked separately

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -22,6 +22,10 @@ class ServiceProvider extends AddonServiceProvider
 
     public function bootAddon(): void
     {
+        $this->publishes([
+            __DIR__.'/../config/statamic/export.php' => config_path('statamic/export.php'),
+        ], 'statamic-export-config');
+
 
         // Register the export action
         Export::register();


### PR DESCRIPTION
Title says it all. Something like the below, which is our use-case, should then work.

```php
'fieldtype_mappings' => [
    \Rias\StatamicAddressField\Fieldtypes\Address::class => function (\Statamic\Fields\Value $address) {
        return collect($address)->only(['street', 'postCode', 'city'])->implode(', ');
    },
],
```