### PR TITLE
Fix: handle non-fieldtype values

### DIFF
--- a/src/Exports/EntriesExport.php
+++ b/src/Exports/EntriesExport.php
@@ -93,6 +93,10 @@ class EntriesExport implements FromCollection, WithStyles
             return '';
         }
 
+        if ($value->value() instanceof \Statamic\Structures\Page) {
+            return $value->value()->id();
+        }
+
         $fieldType = $value->fieldtype();
         $fieldTypeClass = get_class($fieldType);
 


### PR DESCRIPTION
This solves #14 by returning the id of any linked page (most likely, the parent page) instead of handling it as a fieldtype.